### PR TITLE
fix: Zero pad hexidecimal colors

### DIFF
--- a/lua/heirline/utils.lua
+++ b/lua/heirline/utils.lua
@@ -5,7 +5,6 @@ function M.get_highlight(hlname)
     local t = {}
     local hex = function(n)
         if n then
-            -- return string.format("#%x", n)
 			return vim.fn.printf("#%06x", n)
         end
     end

--- a/lua/heirline/utils.lua
+++ b/lua/heirline/utils.lua
@@ -5,7 +5,8 @@ function M.get_highlight(hlname)
     local t = {}
     local hex = function(n)
         if n then
-            return string.format("#%x", n)
+            -- return string.format("#%x", n)
+			return vim.fn.printf("#%06x", n)
         end
     end
     t.fg = hex(hl.foreground)


### PR DESCRIPTION
`utils.get_highlight` returns five character color names when the color starts with a 0 ("#0AAEB3" becomes "#AAEB3" when returned from the plugin, for instance). Using `printf` instead of Lua's `string.format` makes it possible to pad the color with 0s.