### PR TITLE
fix FileSize function in cookbook

### DIFF
--- a/cookbook.md
+++ b/cookbook.md
@@ -621,11 +621,11 @@ local FileSize = {
         local suffix = { 'b', 'k', 'M', 'G', 'T', 'P', 'E' }
         local fsize = vim.fn.getfsize(vim.api.nvim_buf_get_name(0))
         fsize = (fsize < 0 and 0) or fsize
-        if fsize <= 0 then
-            return "0"..suffix[1]
+        if fsize < 1024 then
+            return fsize..suffix[1]
         end
         local i = math.floor((math.log(fsize) / math.log(1024)))
-        return string.format("%.2g%s", fsize / math.pow(1024, i), suffix[i])
+        return string.format("%.2g%s", fsize / math.pow(1024, i), suffix[i + 1])
     end
 }
 ```


### PR DESCRIPTION
FileSize function returned wrong size on files smaller than 1kb and had wrong suffix.
P.S. This plugin is amazing, love the cookbook, thanks!