### PR TITLE
Added Close on middle click to tabline example

### DIFF
--- a/cookbook.md
+++ b/cookbook.md
@@ -1774,8 +1774,12 @@ local TablineFileNameBlock = {
         end
     end,
     on_click = {
-        callback = function(_, minwid)
-            vim.api.nvim_win_set_buf(0, minwid)
+        callback = function(_, minwid, _, button)
+            if (button == "m") then -- close on mouse middle click
+                vim.api.nvim_buf_delete(minwid, {force = true})
+            else
+                vim.api.nvim_win_set_buf(0, minwid)
+            end
         end,
         minwid = function(self)
             return self.bufnr

--- a/cookbook.md
+++ b/cookbook.md
@@ -1776,7 +1776,7 @@ local TablineFileNameBlock = {
     on_click = {
         callback = function(_, minwid, _, button)
             if (button == "m") then -- close on mouse middle click
-                vim.api.nvim_buf_delete(minwid, {force = true})
+                vim.api.nvim_buf_delete(minwid, {force = false})
             else
                 vim.api.nvim_win_set_buf(0, minwid)
             end


### PR DESCRIPTION
Not to sure what the cookbook should contain and what not. (just decline if it is out of scope)
I think close on middle mouse is a quite nice default, that is used across other applications.