### PR TITLE
Fix for adding flexible components

### DIFF
--- a/lua/heirline/utils.lua
+++ b/lua/heirline/utils.lua
@@ -182,13 +182,13 @@ local function group_flexible_components(flexible_components, mode)
             table.insert(priorities, priority)
         end
 
-        local comp = mode == -1 and function(a, b)
-            return a < b
-        end or function(a, b)
-            return a > b
-        end
-        table.sort(priorities, comp)
     end
+    local comp = mode == -1 and function(a, b)
+        return a < b
+    end or function(a, b)
+        return a > b
+    end
+    table.sort(priorities, comp)
     return priority_groups, priorities
 end
 

--- a/lua/heirline/utils.lua
+++ b/lua/heirline/utils.lua
@@ -178,7 +178,7 @@ local function group_flexible_components(flexible_components, mode)
 
         priority_groups[priority] = priority_groups[priority] or {}
         table.insert(priority_groups[priority], component)
-        if not priorities[priority] then
+        if not vim.tbl_contains(priorities, priority) then
             table.insert(priorities, priority)
         end
 


### PR DESCRIPTION
Use `vim.tbl_contains` to ensure a value is not already in the
`priorties` list. `priorities[priority]` may return erroneous answers.
For example, if the first component has a priority value of `2` and the
second component has a priority value of `1`, `priorities[1]` returns
the priority of the first component (2) and not `nil` as expected. This
results in ignoring the second component.