### PR TITLE
fix(cookbook): missing file readonly flag

### DIFF
--- a/cookbook.md
+++ b/cookbook.md
@@ -625,7 +625,7 @@ local FileNameModifer = {
 FileNameBlock = utils.insert(FileNameBlock,
     FileIcon,
     utils.insert(FileNameModifer, FileName), -- a new table where FileName is a child of FileNameModifier
-    unpack(FileFlags), -- A small optimisation, since their parent does nothing
+    FileFlags,
     { provider = '%<'} -- this means that the statusline is cut here when there's not enough space
 )
 


### PR DESCRIPTION
```lua
{
  -- ...
  unpack(FileFlags),
  -- ...
}
```
`unpack` returns a list, but only the first one will be accepted this way, others will be discarded.