### PR TITLE
Improve Buflist Utilities

### DIFF
--- a/lua/heirline/utils.lua
+++ b/lua/heirline/utils.lua
@@ -281,7 +281,7 @@ function M.make_buflist(buffer_component, left_trunc, right_trunc, buf_func, buf
             end
 
             self.active_child = false
-            local bufs = get_bufs()
+            local bufs = buf_func()
             local visible_buffers = bufs_in_tab()
 
             for i, bufnr in ipairs(bufs) do

--- a/lua/heirline/utils.lua
+++ b/lua/heirline/utils.lua
@@ -219,10 +219,13 @@ local NTABLINES = 0
 ---@param left_trunc? table left truncation marker, shown is buffer list is too long
 ---@param right_trunc? table right truncation marker, shown is buffer list is too long
 ---@param buf_func? function return a list of <integer> bufnr handlers.
----@param buf_cache? table reference to the buflist cache
+---@param buf_cache? table reference to the buflist cache or false to disable caching
 ---@return table
 function M.make_buflist(buffer_component, left_trunc, right_trunc, buf_func, buf_cache)
-    buf_func = with_cache(buf_func or get_bufs, buf_cache)
+    buf_func = buf_func or get_bufs
+    if buf_cache ~= false then
+        buf_func = with_cache(buf_func, buf_cache)
+    end
 
     left_trunc = left_trunc or {
         provider = "<",


### PR DESCRIPTION
This does a couple things:

1. It fixes the `make_buflist` utility function to actually use the `buf_func` and cache
2. The second commit allows the user to disable the internal buffer caching. This is very useful if the user's buffer function is already handling this caching and they don't need Heirline to manage a cache of it's own