### PR TITLE
feat: let callback function use all available parameters

### DIFF
--- a/cookbook.md
+++ b/cookbook.md
@@ -157,7 +157,7 @@ Each component may contain _any_ of the following fields:
 - `on_click`:
   - Type: `table` with the following fields:
     - `callback`: (vim/)lua function to be called on mouse click(s). The function
-      has the signature `function(self, minwid, nclicks, button)`
+      has the signature `function(self, minwid, nclicks, button, mods)`
       (see `:h 'statusline'` description for `@`). If a `string` is provided,
       it is interpreted as the _raw_ function name (`v:lua.` is not prepended)
       of an already defined function accessible from vim global scope.

--- a/lua/heirline/statusline.lua
+++ b/lua/heirline/statusline.lua
@@ -233,8 +233,8 @@ local function register_global_function(component)
         return "v:lua." .. func_name
     end
 
-    _G[func_name] = function(minwid, nclicks, button)
-        on_click.callback(component, minwid, nclicks, button)
+    _G[func_name] = function(...)
+        on_click.callback(component, ...)
     end
     return "v:lua." .. func_name
 end


### PR DESCRIPTION
currently the parameters for callback functions are hard coded. This caused us to miss out on the `mods` parameter. We can actually just generalize this to make sure it stays future proof as well. Let me know if you disagree with the generalization and I can just go back and add the `mods` parameter to the hardcoded list