### PR TITLE
Add tabpage handle value to tablist components

### DIFF
--- a/cookbook.md
+++ b/cookbook.md
@@ -369,6 +369,7 @@ These functions are accessible via `require'heirline.conditions'` and
     The cache is released on `BufAdd` and `BufDelete`.
 - `make_tablist(tab_component)`: Returns a component which renders a list of open tabs.
   `tab_component` is the component used to render a single tabpage, it receives the fields:
+  - `self.tabpage <integer>`: the tabpage handle
   - `self.tabnr <integer>`: the tabpage number
   - `self.is_active <bool>`: whether the tabpage is the current tabpage
 - `count_chars(str)`: Returns the character length of `str`. Handles multibyte
@@ -2012,13 +2013,14 @@ create an abstract component that will be used to render each tabpage.
 
 This component will automatically inherit the fields:
 
+- `self.tabpage <integer>`: the tabpage handle
 - `self.tabnr <integer>`: the tabpage number
 - `self.is_active <bool>`: whether the tabpage is the current tabpage
 
 ```lua
 local Tabpage = {
     provider = function(self)
-        return "%" .. self.tabnr .. "T " .. self.tabnr .. " %T"
+        return "%" .. self.tabnr .. "T " .. self.tabpage .. " %T"
     end,
     hl = function(self)
         if not self.is_active then

--- a/lua/heirline/utils.lua
+++ b/lua/heirline/utils.lua
@@ -165,10 +165,10 @@ local function get_bufs()
     end, nvim_list_bufs())
 end
 
-local function bufs_in_tab(tabnr)
-    tabnr = tabnr or 0
+local function bufs_in_tab(tabpage)
+    tabpage = tabpage or 0
     local buf_set = {}
-    local wins = vim.api.nvim_tabpage_list_wins(tabnr)
+    local wins = vim.api.nvim_tabpage_list_wins(tabpage)
     for _, winid in ipairs(wins) do
         local bufnr = vim.api.nvim_win_get_buf(winid)
         buf_set[bufnr] = true
@@ -191,6 +191,7 @@ function M.make_tablist(tab_component)
                     self[i] = self:new(tab_component, i)
                     child = self[i]
                     child.tabnr = tabnr
+                    child.tabpage = tabpage
                 end
                 if tabpage == vim.api.nvim_get_current_tabpage() then
                     child.is_active = true

--- a/lua/heirline/utils.lua
+++ b/lua/heirline/utils.lua
@@ -187,7 +187,7 @@ function M.make_tablist(tab_component)
             for i, tabpage in ipairs(tabpages) do
                 local tabnr = vim.api.nvim_tabpage_get_number(tabpage)
                 local child = self[i]
-                if not (child and child.tabnr == tabnr) then
+                if not (child and child.tabpage == tabpage) then
                     self[i] = self:new(tab_component, i)
                     child = self[i]
                     child.tabnr = tabnr


### PR DESCRIPTION
All the `vim.api.nvim_*` functions take a tabpage handle as an argument, and not a `tabnr`. As it's impossible to recover the handle from the number only, this PR is necessary to enable some features, for example listing all the windows in a given tab.