### PR TITLE
Fix colors in Git

### DIFF
--- a/cookbook.md
+++ b/cookbook.md
@@ -1018,21 +1018,21 @@ local Git = {
             local count = self.status_dict.added or 0
             return count > 0 and ("+" .. count)
         end,
-        hl = { fg = "git_add" },
+        hl = { fg = git_add },
     },
     {
         provider = function(self)
             local count = self.status_dict.removed or 0
             return count > 0 and ("-" .. count)
         end,
-        hl = { fg = "git_del" },
+        hl = { fg = git_del },
     },
     {
         provider = function(self)
             local count = self.status_dict.changed or 0
             return count > 0 and ("~" .. count)
         end,
-        hl = { fg = "git_change" },
+        hl = { fg = git_change },
     },
     {
         condition = function(self)


### PR DESCRIPTION
Strings were passed for the color instead of variables, which causes an invalid color error