### PR TITLE
Update cookbook.md

### DIFF
--- a/cookbook.md
+++ b/cookbook.md
@@ -820,7 +820,7 @@ local Navic = {
 -- Full nerd (with icon colors and clickable elements)!
 -- works in multi window, but does not support flexible components (yet ...)
 local Navic = {
-    condition = require("nvim-navic").is_available,
+    condition = function() return require("nvim-navic").is_available() end,
     static = {
         -- create a type highlight map
         type_hl = {


### PR DESCRIPTION
Hi!
Adding changes to how nvim-navic's is_available function can be called. It seems heirline passes some table as argument by default to "condition" functions. In a recent change to nvim-navic, is_available function can now optionally take buffer number as integer, and error out when its table. So it is necessary to wrap the `is_available` function like so.