### PR TITLE
Fix omission in cookbook.md

### DIFF
--- a/cookbook.md
+++ b/cookbook.md
@@ -812,7 +812,7 @@ new children.
 local Navic = {
     condition = function() return require("nvim-navic").is_available() end,
     provider = function()
-        require("nvim-navic").get_location({highlight=true})
+        return require("nvim-navic").get_location({highlight=true})
     end,
     update = 'CursorMoved'
 }


### PR DESCRIPTION
Good evening.

Came across this when I was trying to set up navic earlier today. In the example the provider does not return anything so the winbar is blank if used.