### PR TITLE
docs(cookbook): remove redrawing of statusline for macro recording co…

### DIFF
--- a/cookbook.md
+++ b/cookbook.md
@@ -556,7 +556,7 @@ local ViMode = {
         return { fg = self.mode_colors[mode], bold = true, }
     end,
     -- Re-evaluate the component only on ModeChanged event!
-    -- Also allorws the statusline to be re-evaluated when entering operator-pending mode
+    -- Also allows the statusline to be re-evaluated when entering operator-pending mode
     update = {
         "ModeChanged",
         pattern = "*:*",
@@ -1252,7 +1252,16 @@ local MacroRec = {
         end,
         hl = { fg = "green", bold = true },
     }),
-    update = { "RecordingEnter", "RecordingLeave" }
+    update = {
+         "RecordingEnter",
+         "RecordingLeave",
+         -- redraw the statusline on recording events
+         -- Note: this is only required for Neovim < 0.9.0. Newer versions of
+         -- Neovim ensure `statusline` is redrawn on those events.
+         callback = vim.schedule_wrap(function()
+             vim.cmd("redrawstatus")
+         end),
+     }
 }
 ```
 

--- a/cookbook.md
+++ b/cookbook.md
@@ -1252,14 +1252,7 @@ local MacroRec = {
         end,
         hl = { fg = "green", bold = true },
     }),
-    update = {
-        "RecordingEnter",
-        "RecordingLeave",
-        -- redraw the statusline on recording events
-        callback = vim.schedule_wrap(function()
-            vim.cmd("redrawstatus")
-        end),
-    }
+    update = { "RecordingEnter", "RecordingLeave" }
 }
 ```
 


### PR DESCRIPTION
…mponent

nvim-0.9.0 (nightly) recently merged in https://github.com/neovim/neovim/pull/22844 which will redraw statusline for macro recording events. After quick test it seems to be working just fine without that callback.

This PR is more to bring it to your attention, likely it shouldn't be merged before new version of Neovim is released and widely adopted.