### PR TITLE
fix(colors): defer loading colors if `colors` is a function

### DIFF
--- a/lua/heirline/colors.lua
+++ b/lua/heirline/colors.lua
@@ -1,0 +1,39 @@
+local M = {}
+
+---@type table<string, string|integer>
+local loaded_colors = {}
+
+---@type nil | fun():table<string, string|integer>
+local deferred_load_colors = nil
+
+local function load(colors)
+    for c, v in pairs(colors) do
+        loaded_colors[c] = v
+    end
+end
+
+---@param colors table<string, string|integer> | fun():table<string, string|integer>
+function M.load(colors)
+    if type(colors) == "function" then
+        deferred_load_colors = function()
+            load(colors())
+            deferred_load_colors = nil
+        end
+    else
+        load(colors)
+    end
+end
+
+---@return table<string, string|integer> loaded_colors
+function M.get()
+    if deferred_load_colors then
+        deferred_load_colors()
+    end
+    return loaded_colors
+end
+
+function M.clear()
+    loaded_colors = {}
+end
+
+return M

--- a/lua/heirline/highlights.lua
+++ b/lua/heirline/highlights.lua
@@ -5,23 +5,17 @@ local tbl_concat = table.concat
 
 local defined_highlights = {}
 
-local loaded_colors = {}
-
 function M.reset_highlights()
     defined_highlights = {}
 end
 
+---@param colors table<string, string|integer> | fun():table<string, string|integer>
 function M.load_colors(colors)
-    for c, v in pairs(colors) do
-        loaded_colors[c] = v
-    end
-end
-
-function M.clear_colors()
-    loaded_colors = {}
+    require("heirline.colors").load(colors)
 end
 
 function M.get_loaded_colors()
+    local loaded_colors = require("heirline.colors").get()
     return vim.tbl_extend("force", loaded_colors, {})
 end
 
@@ -74,6 +68,7 @@ local function hex(val)
 end
 
 local function get_color(val)
+    local loaded_colors = require("heirline.colors").get()
     if type(val) == "string" then
         return loaded_colors[val] or val
     else

--- a/lua/heirline/init.lua
+++ b/lua/heirline/init.lua
@@ -11,10 +11,9 @@ function M.get_highlights()
 end
 
 ---Load color aliases
----@param colors table<string, string|integer>
+---@param colors table<string, string|integer> | fun():table<string, string|integer>
 ---@return nil
 function M.load_colors(colors)
-    colors = type(colors) == "function" and colors() or colors
     return require("heirline.highlights").load_colors(colors)
 end
 


### PR DESCRIPTION
Hey :wave: 

This PR originates from [this rocks.nvim thread](https://github.com/nvim-neorocks/rocks.nvim/discussions/265).

The problem in the discussion is that the colorscheme plugin, mini.base16, requires a `setup` function to configure the colour palette. If the plugin is configured after this plugin's colours are loaded, the palette is not applied.

`heirline.load_colors` accepts a function as an input, and one would expect the function to be evaluated lazily, when needed.
But, it is evaluated immediately, essentially making the fact that you can pass it a function useless.

This PR proposes a change to lazily load the colours when they are needed, if the argument passed into `heirline.load_colors` is a function.
As a result, users don't have to worry about the order in which they configure their plugins.

Apart from that, the behaviour is unchanged.

