### PR TITLE
fix(conditions): make `lsp_attached` use non-deprecated methods

### DIFF
--- a/lua/heirline/conditions.lua
+++ b/lua/heirline/conditions.lua
@@ -61,7 +61,13 @@ function M.has_diagnostics()
 end
 
 function M.lsp_attached()
-    return next(vim.lsp.buf_get_clients()) ~= nil
+    local clients
+    if vim.lsp.get_clients then
+        clients = vim.lsp.get_clients({ bufnr = vim.api.nvim_get_current_buf() })
+    else
+        clients = vim.lsp.buf_get_clients()
+    end
+    return next(clients) ~= nil
 end
 
 return M


### PR DESCRIPTION
Hello! The latest stable release of Neovim (`0.10.0`) has deprecated the `vim.lsp.buf_get_clients` method.

This PR does a check for the newer method to get lsp clients and uses that instead if its available -- otherwise it falls back on `vim.lsp.buf_get_clients`