### PR TITLE
fix(type): add HeirlineConfig & HeirlineInnerOpts types

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ use({
     -- to make sure all required plugins and colorschemes are loaded before setup
     -- event = "UiEnter",
     config = function()
-        require("heirline").setup({...})
+        require("heirline").setup({...} --[[@as HeirlineConfig]])
     end
 })
 ```
@@ -73,7 +73,7 @@ require("heirline").setup({
     winbar = {...},
     tabline = {...},
     statuscolumn = {...},
-})
+} --[[@as HeirlineConfig]])
 ```
 
 Calling `setup` will load your statusline(s). To learn how to write a StatusLine, see the [docs](cookbook.md).

--- a/lua/heirline/init.lua
+++ b/lua/heirline/init.lua
@@ -11,7 +11,7 @@ function M.get_highlights()
 end
 
 ---Load color aliases
----@param colors table<string, string|integer>
+---@param colors table<string, string|integer>|fun():table<string, string|integer>
 ---@return nil
 function M.load_colors(colors)
     colors = type(colors) == "function" and colors() or colors
@@ -67,8 +67,21 @@ local function setup_local_winbar_with_autocmd(callback)
     })
 end
 
+---@class HeirlineInnerOpts
+---@field colors table<string, string|integer>|fun():table<string, string|integer> Define color name aliases.
+---Disable winbar on a per-buffer/window basis.
+---`args` is the table argument passed to autocommand callbacks. See `:h nvim_create_autocmd()`.
+---@field disable_winbar_cb fun(args):boolean
+
+---@class HeirlineConfig
+---@field statusline StatusLine?
+---@field winbar StatusLine?
+---@field tabline StatusLine?
+---@field statuscolumn StatusLine?
+---@field opts HeirlineInnerOpts?
+
 ---Setup
----@param config {statusline: StatusLine, winbar: StatusLine, tabline: StatusLine, statuscolumn: StatusLine, opts: table}
+---@param config HeirlineConfig
 function M.setup(config)
     vim.g.qf_disable_statusline = true
     vim.api.nvim_create_augroup("Heirline_update_autocmds", { clear = true })

--- a/lua/heirline/statusline.lua
+++ b/lua/heirline/statusline.lua
@@ -60,24 +60,24 @@ local default_restrict = {
 ---@field minwid? number|fun(self: StatusLine):integer
 
 ---@class StatusLine
----@field condition? fun(self: StatusLine): any
----@field init? fun(self: StatusLine): any
----@field provider? string|number|fun(self: StatusLine):string|number|nil
----@field hl? HeirlineHighlight|string|fun(self: StatusLine): HeirlineHighlight|string|nil  controls the colors of what is printed by the component's provider, or by any of its descendants.
----@field restrict? table<string, boolean>
----@field after? fun(self: StatusLine): any
----@field update? table|string|fun(self: StatusLine): boolean
----@field on_click? HeirlineOnClickCallback|HeirlineOnClick
----@field id integer[]
----@field winnr integer
----@field fallthrough boolean
----@field flexible integer
----@field _win_cache? table
----@field _au_id? integer
----@field _tree table
----@field _updatable_components table
----@field _flexible_components table
----@field pick_child? integer[]
+---@field condition (fun(self: StatusLine): any)|nil
+---@field init (fun(self: StatusLine): any)|nil
+---@field provider string|number|nil|fun(self: StatusLine):string|number|nil
+---@field hl HeirlineHighlight|string|nil|fun(self: StatusLine): HeirlineHighlight|string|nil  controls the colors of what is printed by the component's provider, or by any of its descendants.
+---@field restrict (table<string, boolean>)|nil
+---@field after (fun(self: StatusLine): any)|nil
+---@field update (table|string|fun(self: StatusLine): boolean)|nil
+---@field on_click (HeirlineOnClickCallback|HeirlineOnClick)|nil
+---@field id (integer[])|nil
+---@field winnr (integer)|nil
+---@field fallthrough boolean?
+---@field flexible integer?
+---@field _win_cache table?
+---@field _au_id integer?
+---@field _tree table?
+---@field _updatable_components table?
+---@field _flexible_components table?
+---@field pick_child (integer[])|nil
 local StatusLine = {}
 
 ---Initialize a new statusline object

--- a/lua/heirline/statusline.lua
+++ b/lua/heirline/statusline.lua
@@ -68,7 +68,7 @@ local default_restrict = {
 ---@field after (fun(self: StatusLine): any)|nil
 ---@field update (table|string|fun(self: StatusLine): boolean)|nil
 ---@field on_click (HeirlineOnClickCallback|HeirlineOnClick)|nil
----@field id (integer[])|nil
+---@field id? integer[]
 ---@field winnr (integer)|nil
 ---@field fallthrough boolean?
 ---@field flexible integer?


### PR DESCRIPTION
The user can now add the type to their configuration to get lsp suggestions for everything, if they're using something like lazydev.nvim or neodev.nvim.
The reason why I `|nil` everything, is because without it, the lsp will scream at the user saying "the required field \[blank\] is not specified", even though it's not actually required.
