### PR TITLE
fix(cookbook): migrate from to `vim.lsp.get_clients`

### DIFF
--- a/cookbook.md
+++ b/cookbook.md
@@ -776,7 +776,7 @@ local LSPActive = {
     -- Or complicate things a bit and get the servers names
     provider = function()
         local names = {}
-        for i, server in pairs(vim.lsp.get_active_clients({ bufnr = 0 })) do
+        for i, server in pairs(vim.lsp.get_clients({ bufnr = 0 })) do
             table.insert(names, server.name)
         end
         return " [" .. table.concat(names, " ") .. "]"


### PR DESCRIPTION
Use instead deprecated vim.lsp.get_active_clients new vim.lsp.get_clients.