### PR TITLE
Fix diagnostic icons in cookbock.md

### DIFF
--- a/cookbook.md
+++ b/cookbook.md
@@ -942,7 +942,7 @@ local Diagnostics = {
         warn_icon = vim.diagnostic.config()['signs']['text'][vim.diagnostic.severity.WARN],
         info_icon = vim.diagnostic.config()['signs']['text'][vim.diagnostic.severity.INFO],
         hint_icon = vim.diagnostic.config()['signs']['text'][vim.diagnostic.severity.HINT],
-    }
+    },
 
     -- If you defined custom LSP diagnostics with vim.fn.sign_define(), use this instead
     -- Note defining custom LSP diagnostic this way its deprecated, though

--- a/cookbook.md
+++ b/cookbook.md
@@ -937,10 +937,12 @@ local Diagnostics = {
     --  },
     --})
     -- Fetching custom diagnostic icons
-    error_icon = vim.diagnostic.config()['signs']['text'][vim.diagnostic.severity.ERROR],
-    warn_icon = vim.diagnostic.config()['signs']['text'][vim.diagnostic.severity.WARN],
-    info_icon = vim.diagnostic.config()['signs']['text'][vim.diagnostic.severity.INFO],
-    hint_icon = vim.diagnostic.config()['signs']['text'][vim.diagnostic.severity.HINT],
+    static = {
+        error_icon = vim.diagnostic.config()['signs']['text'][vim.diagnostic.severity.ERROR],
+        warn_icon = vim.diagnostic.config()['signs']['text'][vim.diagnostic.severity.WARN],
+        info_icon = vim.diagnostic.config()['signs']['text'][vim.diagnostic.severity.INFO],
+        hint_icon = vim.diagnostic.config()['signs']['text'][vim.diagnostic.severity.HINT],
+    }
 
     -- If you defined custom LSP diagnostics with vim.fn.sign_define(), use this instead
     -- Note defining custom LSP diagnostic this way its deprecated, though


### PR DESCRIPTION
Problem is that these keys are not accessible via `self.` later on, if they are not defined in `static`.